### PR TITLE
fix: get correct length of fields

### DIFF
--- a/main.go
+++ b/main.go
@@ -287,7 +287,7 @@ func Report(
 		return fmt.Errorf("could not write column names header: %w", err)
 	}
 
-	numfields := len(mappings)
+	numfields := len(keepers)
 	for rows.Next() {
 		var row []interface{}
 		row, err = rows.SliceScan()


### PR DESCRIPTION
This was in the production-deployed version, but unfortunately somehow not in the release on GitHub. Oppsies.