### PR TITLE
fix(stdout): defer os.Stdout.Close() if used for output

### DIFF
--- a/main.go
+++ b/main.go
@@ -126,6 +126,12 @@ func main() {
 		}
 	}
 
+	if useStdout {
+		defer func() {
+			_ = os.Stdout.Close()
+		}()
+	}
+
 	// Copy once, right away
 	if err := writeRows(useStdout, sqlQuery, outpath, commaStr); nil != err {
 		log.Printf("[ERROR]:\n%v\n", err)


### PR DESCRIPTION
Similar to #7, but specifically for piping to stdout

Note:
I'm not sure if this is actually necessary, or if the system that was having this problem was hanging on to the file descriptor of the binary after it had already been replaced - I've seen that happen many times in Linux.